### PR TITLE
Made the archived scope definition work with paranoia v2 so that the …

### DIFF
--- a/lib/active_admin_paranoia/dsl.rb
+++ b/lib/active_admin_paranoia/dsl.rb
@@ -26,7 +26,7 @@ module ActiveAdminParanoia
       end
 
       scope(I18n.t('active_admin_paranoia.non_archived'), default: true) { |scope| scope.where(resource_class.to_s.camelize.constantize.paranoia_column => resource_class.to_s.camelize.constantize.paranoia_sentinel_value) }
-      scope(I18n.t('active_admin_paranoia.archived')) { |scope| scope.where.not(resource_class.to_s.camelize.constantize.paranoia_column => resource_class.to_s.camelize.constantize.paranoia_sentinel_value) }
+      scope(I18n.t('active_admin_paranoia.archived')) { |scope| scope.unscope(:where => resource_class.to_s.camelize.constantize.paranoia_column).where.not(resource_class.to_s.camelize.constantize.paranoia_column => resource_class.to_s.camelize.constantize.paranoia_sentinel_value) }
     end
   end
 end


### PR DESCRIPTION
…default scope is first unscoped and then the rest of the logic is still applied. Please accept and merge asap - since I need this for my current codebase
