### PR TITLE
Issue #1 'Restore' batch action doesn't work since the 'action_methods'

### DIFF
--- a/lib/active_admin_paranoia/dsl.rb
+++ b/lib/active_admin_paranoia/dsl.rb
@@ -8,7 +8,7 @@ module ActiveAdminParanoia
 
         def action_methods
           if params[:scope] == 'archived'
-            %w(index)
+            %w(index batch_action)
           else
             super
           end


### PR DESCRIPTION
method is overridden and only supplies the 'index' action. Now added the
'batch_action' string as well to the array being returned.
