### PR TITLE
Do not override any default scopes that might have been set

### DIFF
--- a/lib/active_admin_paranoia/dsl.rb
+++ b/lib/active_admin_paranoia/dsl.rb
@@ -5,14 +5,6 @@ module ActiveAdminParanoia
         def find_resource
           resource_class.to_s.camelize.constantize.with_deleted.where(id: params[:id]).first!
         end
-
-        def action_methods
-          if params[:scope] == 'archived'
-            %w(index batch_action)
-          else
-            super
-          end
-        end
       end
 
       batch_action :destroy, confirm: proc{ I18n.t('active_admin.batch_actions.delete_confirmation', plural_model: resource_class.to_s.downcase.pluralize) }, if: proc{ authorized?(ActiveAdmin::Auth::DESTROY, resource_class) && params[:scope] != 'archived' } do |ids|

--- a/lib/active_admin_paranoia/dsl.rb
+++ b/lib/active_admin_paranoia/dsl.rb
@@ -3,7 +3,7 @@ module ActiveAdminParanoia
     def active_admin_paranoia
       controller do
         def find_resource
-          resource_class.to_s.camelize.constantize.unscoped.where(id: params[:id]).first!
+          resource_class.to_s.camelize.constantize.with_deleted.where(id: params[:id]).first!
         end
 
         def action_methods


### PR DESCRIPTION
Also, re-enable other actions for the archived scope.
