### PR TITLE
Show relevant actions for archived index page

### DIFF
--- a/active_admin_paranoia.gemspec
+++ b/active_admin_paranoia.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = %w(lib)
 
-  gem.add_dependency 'rails', '~> 4.0'
-  gem.add_dependency 'paranoia', '~> 1.0'
+  gem.add_dependency 'rails', '>= 4.0'
+  gem.add_dependency 'paranoia', '>= 1.0'
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,4 +18,6 @@ en:
         other: "Successfully restored %{count} %{plural_model}"
     archived: "Archived"
     non_archived: "Non Archived"
+    restore: "Restore"
+    restore_confirmation: "Are you sure you want to restore this?"
     something_wrong: "Something went wrong. Please try again"


### PR DESCRIPTION
The default implementation of the actions does not show relevant info - ie it shows a 'delete' action which is invalid. Instead, show the 'restore' action on this screen.
