### PR TITLE
Fix issue with 'restore' button not appearing correctly since the aut…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
         other: "Successfully restored %{count} %{plural_model}"
     archived: "Archived"
     non_archived: "Non Archived"
+    restore_model: "Restore %{model}"
     restore: "Restore"
     restore_confirmation: "Are you sure you want to restore this?"
     something_wrong: "Something went wrong. Please try again"

--- a/lib/active_admin_paranoia/dsl.rb
+++ b/lib/active_admin_paranoia/dsl.rb
@@ -17,6 +17,10 @@ module ActiveAdminParanoia
         redirect_to :back, notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: ids.count, model: resource_class.to_s.camelize.constantize.model_name, plural_model: resource_class.to_s.downcase.pluralize)
       end
 
+      action_item :restore, only: :show do
+        link_to(I18n.t('active_admin_paranoia.restore_model', model: resource_class.to_s.titleize), "#{resource_path(resource)}/restore", method: :put, data: { confirm: I18n.t('active_admin_paranoia.restore_confirmation') }) if authorized?(ActiveAdminParanoia::Auth::RESTORE, resource)
+      end
+
       member_action :restore, method: :put, confirm: proc{ I18n.t('active_admin_paranoia.restore_confirmation') }, if: proc{ authorized?(ActiveAdminParanoia::Auth::RESTORE, resource_class) } do
         resource.restore(recursive: true)
         redirect_to :back, notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: 1, model: resource_class.to_s.camelize.constantize.model_name, plural_model: resource_class.to_s.downcase.pluralize)
@@ -36,7 +40,7 @@ module ActiveAdmin
 
         def defaults(resource, options = {})
           if resource.respond_to?(:deleted?) && resource.deleted?
-            if controller.action_methods.include?('restore') && authorized?(ActiveAdminParanoia::Auth::RESTORE, resource_class)
+            if controller.action_methods.include?('restore') && authorized?(ActiveAdminParanoia::Auth::RESTORE, resource)
               # TODO: find a way to use the correct path helper
               item I18n.t('active_admin_paranoia.restore'), "#{resource_path(resource)}/restore", method: :put, class: "restore_link #{options[:css_class]}",
                 data: {confirm: I18n.t('active_admin_paranoia.restore_confirmation')}


### PR DESCRIPTION
…horization was being done on the class and not the instance. Also show a 'restore' button in the show action (if the show screen is accessible when the model is in a deleted state (ie as per authorization rules).