### PR TITLE
fix: keep global delete action related wording intact

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ And then execute:
 ```ruby
 ActiveAdmin.register Post do
   active_admin_paranoia
+  actions :all, :except => [:destroy]
 end
 ```

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,17 +1,13 @@
 en:
-  active_admin:
-    delete_model: "Archive %{model}"
-    delete: "Archive"
-    delete_confirmation: "Are you sure you want to archive this?"
+  active_admin_paranoia:
+    archive_model: "Archive %{model}"
+    archive: "Archive"
+    archive_confirmation: "Are you sure you want to archive this?"
     batch_actions:
-      delete_confirmation: "Are you sure you want to archive these %{plural_model}?"
-      succesfully_destroyed:
+      archive_confirmation: "Are you sure you want to archive these %{plural_model}?"
+      succesfully_archived:
         one: "Successfully archived 1 %{model}"
         other: "Successfully archived %{count} %{plural_model}"
-      labels:
-        destroy: "Archive"
-  active_admin_paranoia:
-    batch_actions:
       restore_confirmation: "Are you sure you want to restore these %{plural_model}?"
       succesfully_restored:
         one: "Successfully restored 1 %{model}"

--- a/lib/active_admin_paranoia/authorization.rb
+++ b/lib/active_admin_paranoia/authorization.rb
@@ -1,6 +1,7 @@
 module ActiveAdminParanoia
   # Default Authorization permission for ActiveAdminParanoia
   module Authorization
+    ARCHIVE = :do_archive
     RESTORE = :restore
     PERMANENT_DELETE = :permanent_delete
   end

--- a/lib/active_admin_paranoia/dsl.rb
+++ b/lib/active_admin_paranoia/dsl.rb
@@ -1,26 +1,36 @@
 module ActiveAdminParanoia
   module DSL
     def active_admin_paranoia
-      controller do
-        def find_resource
-          resource_class.to_s.camelize.constantize.with_deleted.where(id: params[:id]).first!
+      archived_at_column = @resource.paranoia_column
+      not_archived_value = @resource.paranoia_sentinel_value
+
+      do_archive = proc do |ids, resource_class, controller|
+        resource_class.where(id: ids).destroy_all
+        options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_archived', count: ids.count, model: resource_class.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
+        # For more info, see here: https://github.com/rails/rails/pull/22506
+        if Rails::VERSION::MAJOR >= 5
+          controller.redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
+        else
+          controller.redirect_to :back, options
         end
       end
 
-      batch_action :destroy, confirm: proc{ I18n.t('active_admin.batch_actions.delete_confirmation', plural_model: resource_class.to_s.downcase.pluralize) }, if: proc{ authorized?(ActiveAdmin::Auth::DESTROY, resource_class) && params[:scope] != 'archived' } do |ids|
-        resource_class.to_s.camelize.constantize.where(id: ids).destroy_all
-        options = { notice: I18n.t('active_admin.batch_actions.succesfully_destroyed', count: ids.count, model: resource_class.to_s.camelize.constantize.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
-        # For more info, see here: https://github.com/rails/rails/pull/22506
-        if Rails::VERSION::MAJOR >= 5
-          redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
-        else
-          redirect_to :back, options
+      controller do
+        def find_resource
+          resource_class.with_deleted.where(id: params[:id]).first!
         end
+      end
+
+      batch_action :archive, confirm: proc{ I18n.t('active_admin_paranoia.batch_actions.archive_confirmation', plural_model: resource_class.to_s.downcase.pluralize) }, if: proc{ authorized?(ActiveAdminParanoia::Auth::ARCHIVE, resource_class) && params[:scope] != 'archived' } do |ids|
+        do_archive.call(ids, resource_class, self)
+      end
+
+      batch_action :destroy, if: proc { false } do
       end
 
       batch_action :restore, confirm: proc{ I18n.t('active_admin_paranoia.batch_actions.restore_confirmation', plural_model: resource_class.to_s.downcase.pluralize) }, if: proc{ authorized?(ActiveAdminParanoia::Auth::RESTORE, resource_class) && params[:scope] == 'archived' } do |ids|
-        resource_class.to_s.camelize.constantize.restore(ids, recursive: true)
-        options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: ids.count, model: resource_class.to_s.camelize.constantize.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
+        resource_class.restore(ids, recursive: true)
+        options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: ids.count, model: resource_class.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
         # For more info, see here: https://github.com/rails/rails/pull/22506
         if Rails::VERSION::MAJOR >= 5
           redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
@@ -29,13 +39,21 @@ module ActiveAdminParanoia
         end
       end
 
-      action_item :restore, only: :show do
+      action_item :archive, only: :show, if: proc { !resource.send(archived_at_column) } do
+        link_to(I18n.t('active_admin_paranoia.archive_model', model: resource_class.to_s.titleize), "#{resource_path(resource)}/archive", method: :put, data: { confirm: I18n.t('active_admin_paranoia.archive_confirmation') }) if authorized?(ActiveAdminParanoia::Auth::ARCHIVE, resource)
+      end
+
+      action_item :restore, only: :show, if: proc { resource.send(archived_at_column) } do
         link_to(I18n.t('active_admin_paranoia.restore_model', model: resource_class.to_s.titleize), "#{resource_path(resource)}/restore", method: :put, data: { confirm: I18n.t('active_admin_paranoia.restore_confirmation') }) if authorized?(ActiveAdminParanoia::Auth::RESTORE, resource)
+      end
+
+      member_action :archive, method: :put, confirm: proc{ I18n.t('active_admin_paranoia.archive_confirmation') }, if: proc{ authorized?(ActiveAdminParanoia::Auth::ARCHIVE, resource_class) } do
+        do_archive.call([resource.id], resource_class, self)
       end
 
       member_action :restore, method: :put, confirm: proc{ I18n.t('active_admin_paranoia.restore_confirmation') }, if: proc{ authorized?(ActiveAdminParanoia::Auth::RESTORE, resource_class) } do
         resource.restore(recursive: true)
-        options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: 1, model: resource_class.to_s.camelize.constantize.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
+        options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: 1, model: resource_class.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
         # For more info, see here: https://github.com/rails/rails/pull/22506
         if Rails::VERSION::MAJOR >= 5
           redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
@@ -44,8 +62,8 @@ module ActiveAdminParanoia
         end
       end
 
-      scope(I18n.t('active_admin_paranoia.non_archived'), default: true) { |scope| scope.where(resource_class.to_s.camelize.constantize.paranoia_column => resource_class.to_s.camelize.constantize.paranoia_sentinel_value) }
-      scope(I18n.t('active_admin_paranoia.archived')) { |scope| scope.unscope(:where => resource_class.to_s.camelize.constantize.paranoia_column).where.not(resource_class.to_s.camelize.constantize.paranoia_column => resource_class.to_s.camelize.constantize.paranoia_sentinel_value) }
+      scope(I18n.t('active_admin_paranoia.non_archived'), default: true) { |scope| scope.where(archived_at_column => not_archived_value) }
+      scope(I18n.t('active_admin_paranoia.archived')) { |scope| scope.unscope(:where => archived_at_column).where.not(archived_at_column => not_archived_value) }
     end
   end
 end


### PR DESCRIPTION
also,
* show Restore button at Show page only if it's archived
* show Delete button at Show page only if it's archived
* removed unneeded to_s...constantize sequences

Notice that if you have custom archive action related translations
you'll need to rename and move them similar to how this commit does in
en.yml.

fixes https://github.com/raihan2006i/active_admin_paranoia/issues/10