### PR TITLE
redirect_back failing from argument error

### DIFF
--- a/lib/active_admin_paranoia/dsl.rb
+++ b/lib/active_admin_paranoia/dsl.rb
@@ -12,7 +12,7 @@ module ActiveAdminParanoia
         options = { notice: I18n.t('active_admin.batch_actions.succesfully_destroyed', count: ids.count, model: resource_class.to_s.camelize.constantize.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
         # For more info, see here: https://github.com/rails/rails/pull/22506
         if Rails::VERSION::MAJOR >= 5
-          redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
+          redirect_back(**{ fallback_location: ActiveAdmin.application.root_to }.merge(options))
         else
           redirect_to :back, options
         end
@@ -23,7 +23,7 @@ module ActiveAdminParanoia
         options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: ids.count, model: resource_class.to_s.camelize.constantize.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
         # For more info, see here: https://github.com/rails/rails/pull/22506
         if Rails::VERSION::MAJOR >= 5
-          redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
+          redirect_back(**{ fallback_location: ActiveAdmin.application.root_to }.merge(options))
         else
           redirect_to :back, options
         end
@@ -38,7 +38,7 @@ module ActiveAdminParanoia
         options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: 1, model: resource_class.to_s.camelize.constantize.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
         # For more info, see here: https://github.com/rails/rails/pull/22506
         if Rails::VERSION::MAJOR >= 5
-          redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
+          redirect_back(**{ fallback_location: ActiveAdmin.application.root_to }.merge(options))
         else
           redirect_to :back, options
         end


### PR DESCRIPTION
Deprecated conversion of keyword arguments causes the redirect_back to raise a ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: fallback_location)

